### PR TITLE
Rename to PinterestApi

### DIFF
--- a/spec/pinterest/api.spec.js
+++ b/spec/pinterest/api.spec.js
@@ -1,21 +1,21 @@
 import _ from 'lodash';
 import Promise from 'bluebird';
 
-import Fields from '../dist/lib/fields';
-import HttpClient from '../dist/lib/http-client';
-import PinterestClient from '../dist/pinterest-client';
-import httpHeaders from '../dist/config/http-headers';
-import {fixtureAsync} from './fixtures';
+import Fields from '../../dist/lib/fields';
+import HttpClient from '../../dist/lib/http-client';
+import PinterestApi from '../../dist/pinterest/api';
+import httpHeaders from '../../dist/config/http-headers';
+import {fixtureAsync} from '../fixtures';
 
 
-describe('PinterestClient', () => {
+describe('PinterestApi', () => {
   let validPinId = '83879611786469438';
   let invalidPinId = '83879611786469438111111100000111';
   let validUserId = '10414780296729982';
   let invalidUserId = '104147802967299821111111111';
   let accessToken = 'this_is_access_token';
   let headers = httpHeaders.randomHeaders();
-  let client = new PinterestClient(accessToken, headers);
+  let client = new PinterestApi(accessToken, headers);
 
   beforeAll(() => HttpClient.disableAutoRetry());
 

--- a/src/bot.js
+++ b/src/bot.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import Promise from 'bluebird';
 
-import PinterestClient from './pinterest-client';
+import PinterestApi from './pinterest/api';
 import Authentication from './lib/authentication';
 import HttpHeaders from './config/http-headers';
 
@@ -12,19 +12,19 @@ export class Bot {
   constructor(accessToken, httpHeaders, type) {
     switch (type) {
       case 'pinterest':
-        this.client = new PinterestClient(accessToken, httpHeaders);
+        this.api = new PinterestApi(accessToken, httpHeaders);
         this.numberOfPages = _.random(3, 5);
     }
   }
 
   performAnUser(user) {
     if (_.randomBoolean()) {
-      return this.client.followUser(user.id);
+      return this.api.followUser(user.id);
     }
   }
 
   performAPin(item) {
-    return this.client.likeAPin(item.id)
+    return this.api.likeAPin(item.id)
       .then((status) => console.log(item.id))
       .catch(console.error)
       .delay(_.random(3000, 10000))
@@ -37,7 +37,7 @@ export class Bot {
       return 0;
     }
 
-    return this.client
+    return this.api
       .getFeeds(25, bookmark).then((body) => {
         if (body.data) {
           let unlikedItems = _(body.data)

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@ import Promise from 'bluebird';
 
 import httpHeaders from './config/http-headers';
 import { Bot } from './bot';
-import TestPinterestClient from './test_pinterest_client';
+import TestPinterestApi from './test_pinterest_api';
 
 
 function checkBot() {
@@ -42,10 +42,10 @@ function checkPromiseUntil() {
     .catch((err) => console.log('*** Error: ' + err));
 }
 
-function testPinterestClient() {
-  let test = new TestPinterestClient();
+function testPinterestApi() {
+  let test = new TestPinterestApi();
   test.run();
 }
 
-testPinterestClient();
+testPinterestApi();
 // checkBot();

--- a/src/pinterest/api.js
+++ b/src/pinterest/api.js
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 import Promise from 'bluebird';
 
-import HttpClient from './lib/http-client';
-import Fields from './lib/fields';
-import {HttpHandlersMixin} from './mixins/http-handlers';
+import HttpClient from '../lib/http-client';
+import Fields from '../lib/fields';
+import {HttpHandlersMixin} from '../mixins/http-handlers';
 
 
 const DOMAIN = 'https://api.pinterest.com/v3';
@@ -49,7 +49,7 @@ function getSearchPath(type) {
   }
 }
 
-export default class PinterestClient {
+export default class PinterestApi {
   constructor(accessToken, httpHeaders) {
     this.accessToken = accessToken;
     this.httpHeaders = _.clone(httpHeaders);
@@ -232,4 +232,4 @@ export default class PinterestClient {
   }
 }
 
-_.extend(PinterestClient.prototype, HttpHandlersMixin);
+_.extend(PinterestApi.prototype, HttpHandlersMixin);

--- a/src/pinterest/client.js
+++ b/src/pinterest/client.js
@@ -1,0 +1,13 @@
+import _ from 'lodash';
+import Promise from 'bluebird';
+
+import PinterestApi from './api';
+
+
+export default class PinterestClient {
+  constructor(accessToken, httpHeaders) {
+    this.api = new PinterestApi(accessToken, httpHeaders);
+  }
+
+  // Methods go here
+}

--- a/src/test_pinterest_api.js
+++ b/src/test_pinterest_api.js
@@ -1,24 +1,24 @@
 import _ from 'lodash';
 import Promise from 'bluebird';
 
-import PinterestClient from './pinterest-client';
+import PinterestApi from './pinterest/api';
 import Authentication from './lib/authentication';
 import HttpHeaders from './config/http-headers';
 
 import './exts/lodash';
 
 
-export default class TestPinterestClient {
+export default class TestPinterestApi {
   constructor() {
     /*eslint-disable*/
     let accessToken = 'MTQzMTYwMjo0MjQ4MTYzMTQ3NTkwMTAwMjk6OTIyMzM3MjAzNjg1NDc3NTgwNzoxfDE0Mjg4MjI1ODE6MC0tODIxZmVjYzg2NWNlYThmMmNmYzE0YWIzNTIwMGFlMTU=';
     /*eslint-enable*/
     let headers = HttpHeaders.randomHeaders();
-    this.client = new PinterestClient(accessToken, headers);
+    this.api = new PinterestApi(accessToken, headers);
   }
 
   run() {
-    this.client
+    this.api
       .repin('297870962830963512', '424816246039791020', `♡ Father's Day`)
       .then((data) => {
         console.log(data);


### PR DESCRIPTION
- PinterestClient sẽ bao gồm các action của Pinterest.
  - Mỗi action là 1 tổ hợp các lệnh của PinterestClient
  - VD: findAnUser = 1 vài lệnh autocomplete + search + ...
  - VD: repin = getPinDetail + getBoardsOfMe + repin
- PinterestApi (trước đây là PinterestClient) sẽ bao gồm các HTTP
  request gửi lên server.
- Bot sẽ sử dụng các action ở trong PinterestClient, cái này sẽ được
  move trong PR sau.
